### PR TITLE
Router and route filters

### DIFF
--- a/backbone.blazer.js
+++ b/backbone.blazer.js
@@ -110,7 +110,7 @@ Backbone.Blazer.Router = Backbone.Router.extend({
         }, null);
 
         if (chain) {
-            chain.then(def.resolve, def.reject);
+            chain.then(def.resolve);
         } else {
             def.resolve();
         }

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -18,6 +18,25 @@ var RouteThatErrors = Backbone.Blazer.Route.extend({
     }
 });
 
+var RouteWithFilter = Backbone.Blazer.Route.extend({
+    filters: [{
+        beforeRoute: function(routeData) {
+            console.log('RouteWithFilter beforeRoute', routeData);
+        },
+        afterRoute: function(routeData) {
+            console.log('RouteWithFilter afterRoute', routeData);
+        }
+    }],
+
+    prepare: function(routeData) {
+        console.log('RouteWithFilter prepare', routeData);
+    },
+
+    execute: function(routeData) {
+        console.log('RouteWithFilter execute', routeData);
+    }
+});
+
 var Router = Backbone.Blazer.Router.extend({
     routes: {
         'examples/basic/function': function(routeData) {
@@ -25,7 +44,8 @@ var Router = Backbone.Blazer.Router.extend({
         },
         'examples/basic/method': 'method',
         'examples/basic/routeObject': new Route(),
-        'examples/basic/routeObjectError': new RouteThatErrors()
+        'examples/basic/routeObjectError': new RouteThatErrors(),
+        'examples/basic/routeFilters': new RouteWithFilter()
     },
     method: function(routeData) {
         console.log('Method route matched', routeData);

--- a/test/backbone.blazer.spec.js
+++ b/test/backbone.blazer.spec.js
@@ -51,8 +51,8 @@ describe('Backbone.Blazer.Router', function() {
 
     it('should run a single before and after filter attached to the router', function() {
         this.router.filters = [{
-            beforeRoute: sinon.spy(),
-            afterRoute: sinon.spy()
+            beforeRoute: this.sinon.spy(),
+            afterRoute: this.sinon.spy()
         }];
 
         this.router.navigate('route', { trigger: true });
@@ -63,8 +63,8 @@ describe('Backbone.Blazer.Router', function() {
 
     it('should run filters attached to a route', function() {
         this.testRoute.filters = [{
-            beforeRoute: sinon.spy(),
-            afterRoute: sinon.spy()
+            beforeRoute: this.sinon.spy(),
+            afterRoute: this.sinon.spy()
         }];
 
         this.router.navigate('route', { trigger: true });


### PR DESCRIPTION
- Filters can be attached at the router or route level
- The `filters` property of either the router or route is an array of plain objects
  with either a beforeRoute method, afterRoute method, or both
- The beforeRoute and afterRoute methods can return a value or a promise
- Filters are executed
  - in the order they are defined, and in the same order before and after execution
  - in the root context (so, `window`) so they can't modify any router or route state
  - BEFORE the `prepare` method on the route, which we can debate

@samandmoore 
