### PR TITLE
Refactor redirects to use a rejected promise instead of a POJO

### DIFF
--- a/backbone.blazer.js
+++ b/backbone.blazer.js
@@ -17,9 +17,9 @@ _.extend(Backbone.Blazer.Route.prototype, Backbone.Events, {
     execute: function() {},
     error: function() {},
     redirect: function(fragment) {
-        return {
+        return $.Deferred().reject({
             redirectFragment: fragment
-        };
+        }).promise();
     }
 });
 
@@ -112,7 +112,7 @@ Backbone.Blazer.Router = Backbone.Router.extend({
             def = $.Deferred();
 
         var chain = _.reduce(stageFilters, function(previous, filter) {
-            
+
             if (!previous) {
                 return router._runHandler(filter, router, route, routeData);
             }
@@ -133,13 +133,10 @@ Backbone.Blazer.Router = Backbone.Router.extend({
     },
 
     _runHandler: function(handler, router, route, routeData) {
-        var result = handler.call(route, routeData);
-
-        if (result && result.redirectFragment) {
-            router.navigate(result.redirectFragment, { trigger: true });
-            return $.Deferred().reject().promise();
-        }
-
-        return $.when(result);
+        return $.when(handler.call(route, routeData)).fail(function(result) {
+            if (result && result.redirectFragment) {
+                router.navigate(result.redirectFragment, { trigger: true });
+            }
+        });
     }
 });

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -37,6 +37,17 @@ var RouteWithFilter = Backbone.Blazer.Route.extend({
     }
 });
 
+var RouteWithRedirect = Backbone.Blazer.Route.extend({
+    prepare: function(routeData) {
+        console.log('RouteWithRedirect prepare', routeData);
+        return this.redirect('examples/basic/routeObject');
+    },
+
+    execute: function(routeData) {
+        console.log('This never happens!');
+    }
+});
+
 var Router = Backbone.Blazer.Router.extend({
     routes: {
         'examples/basic/function': function(routeData) {
@@ -45,7 +56,8 @@ var Router = Backbone.Blazer.Router.extend({
         'examples/basic/method': 'method',
         'examples/basic/routeObject': new Route(),
         'examples/basic/routeObjectError': new RouteThatErrors(),
-        'examples/basic/routeFilters': new RouteWithFilter()
+        'examples/basic/routeFilters': new RouteWithFilter(),
+        'examples/basic/redirect': new RouteWithRedirect()
     },
     method: function(routeData) {
         console.log('Method route matched', routeData);

--- a/test/backbone.blazer.spec.js
+++ b/test/backbone.blazer.spec.js
@@ -3,7 +3,7 @@ describe('Backbone.Blazer.Router', function() {
     var TestRoute = Backbone.Blazer.Route.extend({
         execute: function() {}
     });
-    
+
     var RedirectRoute = Backbone.Blazer.Route.extend({
         execute: function() {}
     });
@@ -271,6 +271,58 @@ describe('Backbone.Blazer.Router', function() {
 
         this.router.navigate('route', { trigger: true });
 
+        expect(this.redirectRoute.execute).to.have.been.called;
+    });
+
+    it('should not trigger an error when redirecting from prepare', function() {
+        this.sinon.stub(this.testRoute, 'prepare', function() { return this.redirect('redirect') });
+        this.sinon.spy(this.testRoute, 'error');
+        this.sinon.spy(this.redirectRoute, 'execute');
+
+        this.router.navigate('route', { trigger: true });
+
+        expect(this.testRoute.error).to.not.have.been.called;
+        expect(this.redirectRoute.execute).to.have.been.called;
+    });
+
+    it('should not trigger an error when redirecting from a filter', function() {
+        this.testRoute.filters = [{
+            beforeRoute: function() { return this.redirect('redirect') }
+        }];
+        this.sinon.spy(this.testRoute, 'error');
+        this.sinon.spy(this.redirectRoute, 'execute');
+
+        this.router.navigate('route', { trigger: true });
+
+        expect(this.testRoute.error).to.not.have.been.called;
+        expect(this.redirectRoute.execute).to.have.been.called;
+    });
+
+    it('should not trigger the error event when redirecting from prepare', function() {
+        this.sinon.stub(this.testRoute, 'prepare', function() { return this.redirect('redirect') });
+        this.sinon.spy(this.redirectRoute, 'execute');
+
+        var errorSpy = this.sinon.spy();
+        this.testRoute.on('error', errorSpy);
+
+        this.router.navigate('route', { trigger: true });
+
+        expect(errorSpy).to.not.have.been.called;
+        expect(this.redirectRoute.execute).to.have.been.called;
+    });
+
+    it('should not trigger the error event when redirecting from filter', function() {
+        this.testRoute.filters = [{
+            beforeRoute: function() { return this.redirect('redirect') }
+        }];
+        this.sinon.spy(this.redirectRoute, 'execute');
+
+        var errorSpy = this.sinon.spy();
+        this.testRoute.on('error', errorSpy);
+
+        this.router.navigate('route', { trigger: true });
+
+        expect(errorSpy).to.not.have.been.called;
         expect(this.redirectRoute.execute).to.have.been.called;
     });
 


### PR DESCRIPTION
@samandmoore @adamlangsner 

For some reason this clicked in my head this morning so I wanted to see what you guys thought. Instead of returning a special object, it uses the existing mechanism to kill the before-execute methods with a rejected deferred, and the fragment is passed to the promise callbacks.
